### PR TITLE
Change: Allow embedding any file into a .cat file.

### DIFF
--- a/src/io.cpp
+++ b/src/io.cpp
@@ -26,6 +26,9 @@
 FileReader::FileReader(const std::string &filename, bool binary)
 {
 	this->file = fopen(filename.c_str(), binary ? "rb" : "r");
+	fseek(this->file, 0, SEEK_END);
+	this->filesize = ftell(this->file);
+	fseek(this->file, 0, SEEK_SET);
 	this->filename = filename;
 
 	if (this->file == NULL) {

--- a/src/io.hpp
+++ b/src/io.hpp
@@ -28,6 +28,7 @@
  */
 class FileReader {
 	FILE *file;      ///< The file to be read by this instance
+	size_t filesize; ///< The size of the file
 	std::string filename; ///< The filename of the file
 
 public:
@@ -88,6 +89,12 @@ public:
 	 * @return the position in the stream
 	 */
 	uint32_t GetPos();
+
+	/**
+	 * Get the size of the file.
+	 * @return the size of the file
+	 */
+	inline size_t GetSize() const { return this->filesize; }
 
 	/**
 	 * Get the filename of this file.

--- a/src/sample.cpp
+++ b/src/sample.cpp
@@ -91,7 +91,12 @@ Sample::Sample(const std::string &filename, const std::string &name) :
 	filename(filename)
 {
 	FileReader sample_reader(filename);
-	this->ReadSample(sample_reader, false);
+	if (!this->ReadSample(sample_reader, false)) {
+		/* File was not WAV, treat as raw. */
+		this->size = static_cast<uint32_t>(sample_reader.GetSize());
+		this->sample_data.resize(this->size);
+		sample_reader.ReadRaw(this->sample_data.data(), this->sample_data.size());
+	}
 }
 
 bool Sample::ReadSample(FileReader &reader, bool check_size)
@@ -100,7 +105,6 @@ bool Sample::ReadSample(FileReader &reader, bool check_size)
 
 	uint32_t pos = reader.GetPos();
 	if (reader.ReadDword() != 'FFIR') {
-		if (!check_size) throw "Unexpected chunk; expected \"RIFF\" in " + reader.GetFilename();
 		reader.Seek(pos);
 		return false;
 	}
@@ -160,7 +164,7 @@ void Sample::ReadCatEntry(FileReader &reader, bool new_format, uint32_t index)
 		this->sample_data.resize(this->size);
 		reader.ReadRaw(this->sample_data.data(), this->sample_data.size());
 
-		this->size += RIFF_HEADER_SIZE;
+		if (!new_format) this->size += RIFF_HEADER_SIZE;
 	}
 
 	if (!new_format) {
@@ -185,6 +189,12 @@ void Sample::ReadCatEntry(FileReader &reader, bool new_format, uint32_t index)
 
 void Sample::WriteSample(FileWriter &writer) const
 {
+	if (this->num_channels == 0) {
+		/* No channels means this is a raw file and should be written as-is. */
+		writer.WriteRaw(this->sample_data.data(), this->sample_data.size());
+		return;
+	}
+
 	writer.WriteDword('FFIR');
 	writer.WriteDword(this->size - 8);
 	writer.WriteDword('EVAW');

--- a/src/sample.hpp
+++ b/src/sample.hpp
@@ -31,15 +31,15 @@
  */
 class Sample {
 private:
-	uint32_t offset;          ///< Offset from the begin of the cat
-	uint32_t size;            ///< The size of the WAV RIFF, i.e. excluding name and filename
+	uint32_t offset = 0; ///< Offset from the begin of the cat
+	uint32_t size = 0; ///< The size of the WAV RIFF, i.e. excluding name and filename
 
-	std::string name;              ///< The name of the sample
-	std::string filename;          ///< The filename of the sample
+	std::string name; ///< The name of the sample
+	std::string filename; ///< The filename of the sample
 
-	uint16_t num_channels;    ///< Number of channels; either 1 or 2
-	uint32_t sample_rate;     ///< Sample rate; either 11025, 22050 or 44100
-	uint16_t bits_per_sample; ///< Number of bits per sample; either 8 or 16
+	uint32_t sample_rate = 0; ///< Sample rate; either 11025, 22050 or 44100
+	uint16_t num_channels = 0; ///< Number of channels; either 1 or 2
+	uint16_t bits_per_sample = 0; ///< Number of bits per sample; either 8 or 16
 
 	std::vector<uint8_t> sample_data; ///< The actual raw sample data
 


### PR DESCRIPTION
To support OpenTTD/OpenTTD#13055, catcodec needs to be extended to allow Ogg Opus files to be included.

To properly test for a valid Ogg Opus files would require additional dependencies and complicated code to test each file, so this PR takes the approach of allowing any file to be packed into the .cat file and it's up to the user to ensure the files are correct.

This allows file types other than WAV to be embedded. File types not supported by OpenTTD will be ignored.