### PR TITLE
Codechange: Various C++ cleanups.

### DIFF
--- a/src/catcodec.cpp
+++ b/src/catcodec.cpp
@@ -202,7 +202,7 @@ int main(int argc, char *argv[])
 		strncpy(sfo_file, argv[2], sizeof(sfo_file));
 		char *ext = strrchr(sfo_file, '.');
 		if (ext == NULL || strlen(ext) != 4 || strcmp(ext, ".cat") != 0) {
-			throw string("Unexpected extension; expected \".cat\"");
+			throw std::string("Unexpected extension; expected \".cat\"");
 		}
 		strcpy(ext, ".sfo");
 
@@ -235,7 +235,7 @@ int main(int argc, char *argv[])
 		}
 		if (_interactive) printf("\nDone\n");
 
-	} catch (const string &s) {
+	} catch (const std::string &s) {
 		fprintf(stderr, "An error occured: %s\n", s.c_str());
 		ret = -1;
 	}

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -23,7 +23,7 @@
 #include "stdafx.h"
 #include "io.hpp"
 
-FileReader::FileReader(string filename, bool binary)
+FileReader::FileReader(const std::string &filename, bool binary)
 {
 	this->file = fopen(filename.c_str(), binary ? "rb" : "r");
 	this->filename = filename;
@@ -84,13 +84,13 @@ uint32_t FileReader::GetPos()
 	return ftell(this->file);
 }
 
-string FileReader::GetFilename() const
+const std::string &FileReader::GetFilename() const
 {
 	return this->filename;
 }
 
 
-FileWriter::FileWriter(string filename, bool binary)
+FileWriter::FileWriter(const std::string &filename, bool binary)
 {
 	this->filename_new = filename + ".new";
 	this->filename = filename;
@@ -156,7 +156,7 @@ uint32_t FileWriter::GetPos()
 	return ftell(this->file);
 }
 
-string FileWriter::GetFilename() const
+const std::string &FileWriter::GetFilename() const
 {
 	return this->filename;
 }
@@ -168,7 +168,7 @@ void FileWriter::Close()
 	this->file = NULL;
 
 	/* Then remove the existing .bak file */
-	string filename_bak = this->filename + ".bak";
+	std::string filename_bak = this->filename + ".bak";
 	if (unlink(filename_bak.c_str()) != 0 && errno != ENOENT) {
 		fprintf(stderr, "Warning: could not remove %s (%s)\n", filename_bak.c_str(), strerror(errno));
 	}

--- a/src/io.hpp
+++ b/src/io.hpp
@@ -23,15 +23,12 @@
 #ifndef IO_H
 #define IO_H
 
-/** A string is a string; simple as that */
-typedef std::string string;
-
 /**
  * Simple class to perform binary and string reading from a file.
  */
 class FileReader {
 	FILE *file;      ///< The file to be read by this instance
-	string filename; ///< The filename of the file
+	std::string filename; ///< The filename of the file
 
 public:
 	/**
@@ -39,7 +36,7 @@ public:
 	 * @param filename the file to read from
 	 * @param binary   read the file as binary or text?
 	 */
-	FileReader(string filename, bool binary = true);
+	FileReader(const std::string &filename, bool binary = true);
 
 	/**
 	 * Cleans up our mess
@@ -96,7 +93,7 @@ public:
 	 * Get the filename of this file.
 	 * @return the filename
 	 */
-	string GetFilename() const;
+	const std::string &GetFilename() const;
 };
 
 /**
@@ -104,8 +101,8 @@ public:
  */
 class FileWriter {
 	FILE *file;          ///< The file to be read by this instance
-	string filename;     ///< The filename of the file
-	string filename_new; ///< The filename for the temporary file
+	std::string filename;     ///< The filename of the file
+	std::string filename_new; ///< The filename for the temporary file
 
 public:
 	/**
@@ -113,7 +110,7 @@ public:
 	 * @param filename the file to write to
 	 * @param binary   write the file as binary or text?
 	 */
-	FileWriter(string filename, bool binary = true);
+	FileWriter(const std::string &filename, bool binary = true);
 
 	/**
 	 * Cleans up our mess
@@ -162,7 +159,7 @@ public:
 	 * Get the filename of this file.
 	 * @return the filename
 	 */
-	string GetFilename() const;
+	const std::string &GetFilename() const;
 
 	/**
 	 * Close the output, i.e. commit the file to disk.

--- a/src/sample.cpp
+++ b/src/sample.cpp
@@ -55,7 +55,7 @@ static const uint32_t RIFF_HEADER_SIZE = 44;
  * @param reader the reader to read from
  * @return the read string
  */
-static string ReadString(FileReader &reader)
+static std::string ReadString(FileReader &reader)
 {
 	uint8_t name_len = reader.ReadByte();
 	char buffer[256];
@@ -71,7 +71,7 @@ static string ReadString(FileReader &reader)
  * @param str    the string to write
  * @param writer the writer to write to
  */
-static void WriteString(const string str, FileWriter &writer)
+static void WriteString(const std::string &str, FileWriter &writer)
 {
 	uint8_t str_len = (uint8_t)(str.length() + 1);
 	writer.WriteByte(str_len);
@@ -85,7 +85,7 @@ Sample::Sample(FileReader &reader)
 	this->size   = reader.ReadDword();
 }
 
-Sample::Sample(string filename, string name) :
+Sample::Sample(const std::string &filename, const std::string &name) :
 	offset(0),
 	name(name),
 	filename(filename)
@@ -210,12 +210,12 @@ void Sample::WriteCatEntry(FileWriter &writer) const
 	WriteString(this->GetFilename(), writer);
 }
 
-string Sample::GetName() const
+const std::string &Sample::GetName() const
 {
 	return this->name;
 }
 
-string Sample::GetFilename() const
+const std::string &Sample::GetFilename() const
 {
 	return this->filename;
 }

--- a/src/sample.hpp
+++ b/src/sample.hpp
@@ -137,6 +137,6 @@ public:
 };
 
 /** Lets have us a vector of samples */
-typedef std::vector<Sample *> Samples;
+using Samples = std::vector<Sample>;
 
 #endif /* SAMPLE_HPP */

--- a/src/sample.hpp
+++ b/src/sample.hpp
@@ -34,8 +34,8 @@ private:
 	uint32_t offset;          ///< Offset from the begin of the cat
 	uint32_t size;            ///< The size of the WAV RIFF, i.e. excluding name and filename
 
-	string name;              ///< The name of the sample
-	string filename;          ///< The filename of the sample
+	std::string name;              ///< The name of the sample
+	std::string filename;          ///< The filename of the sample
 
 	uint16_t num_channels;    ///< Number of channels; either 1 or 2
 	uint32_t sample_rate;     ///< Sample rate; either 11025, 22050 or 44100
@@ -58,7 +58,7 @@ public:
 	 * @param filename the file to read the sample from
 	 * @param name     the name of the sample
 	 */
-	Sample(string filename, string name);
+	Sample(const std::string &filename, const std::string &name);
 
 	/**
 	 * Reads a sample from a reader.
@@ -95,13 +95,13 @@ public:
 	 * Get the name of the sample.
 	 * @return the name of the sample
 	 */
-	string GetName() const;
+	const std::string &GetName() const;
 
 	/**
 	 * Get the filename of the sample
 	 * @return the filename of the sample
 	 */
-	string GetFilename() const;
+	const std::string &GetFilename() const;
 
 
 	/**

--- a/src/sample.hpp
+++ b/src/sample.hpp
@@ -42,7 +42,7 @@ private:
 	uint16_t bits_per_sample; ///< Number of bits per sample; either 8 or 16
 
 	uint32_t sample_size;     ///< The size of the raw data below
-	uint8_t *sample_data;     ///< The actual raw sample data
+	std::vector<uint8_t> sample_data; ///< The actual raw sample data
 
 public:
 	/**
@@ -59,12 +59,6 @@ public:
 	 * @param name     the name of the sample
 	 */
 	Sample(string filename, string name);
-
-	/**
-	 * Cleans up our mess.
-	 */
-	~Sample();
-
 
 	/**
 	 * Reads a sample from a reader.

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -25,6 +25,7 @@
 
 #include <cstdarg>
 #include <cstdio>
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 
@@ -33,9 +34,6 @@
 #include <string>
 
 #if defined(_MSC_VER)
-	typedef unsigned char    uint8_t;
-	typedef unsigned short   uint16_t;
-	typedef unsigned int     uint32_t;
 	#define UNUSED
 
 	#define fileno _fileno


### PR DESCRIPTION
Various cleanups to C++-ify the code:

* Samples is now a `std::vector<Sample>` instead of `std::vector<Sample *>`. Samples pointers are not stored anywhere else so there's no worry about its location changing if the vector is reallocated. This simplifies clean up as no pointers need to be deleted.
* Sample data is now stored in a `std::vector<uint8_t>` instead of a raw pointer allocated with `malloc()`. This avoids needing to manually `free()` during clean up.
* Removed `typedef std::string string` in favour of just using `std::string` everywhere, and use `const std::string &` when we're passing an existing string without making a copy.
* Include `cstdint`, instead of defining `uintX_t` on Windows.