### PR TITLE
Fix b417099: sample data is allowed to be empty

### DIFF
--- a/src/sample.cpp
+++ b/src/sample.cpp
@@ -175,8 +175,6 @@ void Sample::ReadCatEntry(FileReader &reader, bool new_format)
 
 void Sample::WriteSample(FileWriter &writer) const
 {
-	assert(!this->sample_data.empty());
-
 	writer.WriteDword('FFIR');
 	writer.WriteDword(this->size - 8);
 	writer.WriteDword('EVAW');
@@ -197,8 +195,6 @@ void Sample::WriteSample(FileWriter &writer) const
 
 void Sample::WriteCatEntry(FileWriter &writer) const
 {
-	assert(!this->sample_data.empty());
-
 	if (writer.GetPos() != this->GetOffset()) throw "Invalid offset when writing file " + writer.GetFilename();
 
 	WriteString(this->GetName(), writer);


### PR DESCRIPTION
b417099 changed from using raw C-style manual memory allocation to vectors, but unfortunately converted a null pointer check into a zero-size check.

Empty samples are actually expected (both sample.cat and opensfx.cat contain empty samples), so this check can simply be removed.