### PR TITLE
Codechange: remove unnecessary sample_size member

### DIFF
--- a/src/sample.cpp
+++ b/src/sample.cpp
@@ -133,11 +133,11 @@ void Sample::ReadSample(FileReader &reader, bool check_size)
 	 * wrong offset further on, so just read whatever amount of data was
 	 * specified in the top RIFF as long as sample size is within those
 	 * boundaries, i.e. within the RIFF. */
-	this->sample_size = reader.ReadDword();
-	if (this->sample_size + RIFF_HEADER_SIZE > size) throw "Unexpected data chunk size in " + reader.GetFilename();
+	uint32_t sample_size = reader.ReadDword();
+	if (sample_size + RIFF_HEADER_SIZE > this->size) throw "Unexpected data chunk size in " + reader.GetFilename();
 
 	this->sample_data.resize(this->size - RIFF_HEADER_SIZE);
-	reader.ReadRaw(this->sample_data.data(), this->size - RIFF_HEADER_SIZE);
+	reader.ReadRaw(this->sample_data.data(), this->sample_data.size());
 }
 
 void Sample::ReadCatEntry(FileReader &reader, bool new_format)
@@ -150,9 +150,8 @@ void Sample::ReadCatEntry(FileReader &reader, bool new_format)
 
 	if (!new_format && this->GetName().compare("Corrupt sound") == 0) {
 		/* In the old format there was one sample that was raw PCM. */
-		this->sample_size     = this->size;
-		this->sample_data.resize(this->sample_size);
-		reader.ReadRaw(this->sample_data.data(), this->sample_size);
+		this->sample_data.resize(this->size);
+		reader.ReadRaw(this->sample_data.data(), this->sample_data.size());
 
 		this->size += RIFF_HEADER_SIZE;
 	} else {
@@ -189,8 +188,8 @@ void Sample::WriteSample(FileWriter &writer) const
 	writer.WriteWord(this->bits_per_sample);
 
 	writer.WriteDword('atad');
-	writer.WriteDword(this->sample_size);
-	writer.WriteRaw(this->sample_data.data(), this->size - RIFF_HEADER_SIZE);
+	writer.WriteDword(static_cast<uint32_t>(this->sample_data.size()));
+	writer.WriteRaw(this->sample_data.data(), this->sample_data.size());
 }
 
 void Sample::WriteCatEntry(FileWriter &writer) const

--- a/src/sample.hpp
+++ b/src/sample.hpp
@@ -41,7 +41,6 @@ private:
 	uint32_t sample_rate;     ///< Sample rate; either 11025, 22050 or 44100
 	uint16_t bits_per_sample; ///< Number of bits per sample; either 8 or 16
 
-	uint32_t sample_size;     ///< The size of the raw data below
 	std::vector<uint8_t> sample_data; ///< The actual raw sample data
 
 public:


### PR DESCRIPTION
Now that sample data is stored in a vector, there is no need to store the size of the sample data separately in the in the `sample_size` member.

We can now just use the size of the sample data instead, which is also safer.