### PR TITLE
Fix: catcodec could not decode sample.cat from DOS versions of original data

### DIFF
--- a/src/catcodec.cpp
+++ b/src/catcodec.cpp
@@ -55,8 +55,9 @@ static void ReadCat(Samples &samples, FileReader &reader)
 		samples.emplace_back(reader);
 	}
 
-	for (auto iter = samples.begin(); iter != samples.end(); ++iter) {
-		iter->ReadCatEntry(reader, new_format);
+	uint32_t index = 0;
+	for (auto iter = samples.begin(); iter != samples.end(); ++iter, ++index) {
+		iter->ReadCatEntry(reader, new_format, index);
 		ShowProgress();
 	}
 }

--- a/src/sample.cpp
+++ b/src/sample.cpp
@@ -94,14 +94,19 @@ Sample::Sample(const std::string &filename, const std::string &name) :
 	this->ReadSample(sample_reader, false);
 }
 
-void Sample::ReadSample(FileReader &reader, bool check_size)
+bool Sample::ReadSample(FileReader &reader, bool check_size)
 {
 	assert(this->sample_data.empty());
 
-	if (reader.ReadDword() != 'FFIR') throw "Unexpected chunk; expected \"RIFF\" in " + reader.GetFilename();
+	uint32_t pos = reader.GetPos();
+	if (reader.ReadDword() != 'FFIR') {
+		if (!check_size) throw "Unexpected chunk; expected \"RIFF\" in " + reader.GetFilename();
+		reader.Seek(pos);
+		return false;
+	}
 
 	if (check_size) {
-		if (reader.ReadDword() + 8  != size  ) throw "Unexpected RIFF chunk size in " + reader.GetFilename();
+		if (reader.ReadDword() + 8 != size) throw "Unexpected RIFF chunk size in " + reader.GetFilename();
 	} else {
 		this->size = reader.ReadDword() + 8;
 	}
@@ -138,9 +143,10 @@ void Sample::ReadSample(FileReader &reader, bool check_size)
 
 	this->sample_data.resize(this->size - RIFF_HEADER_SIZE);
 	reader.ReadRaw(this->sample_data.data(), this->sample_data.size());
+	return true;
 }
 
-void Sample::ReadCatEntry(FileReader &reader, bool new_format)
+void Sample::ReadCatEntry(FileReader &reader, bool new_format, uint32_t index)
 {
 	assert(this->sample_data.empty());
 
@@ -148,14 +154,13 @@ void Sample::ReadCatEntry(FileReader &reader, bool new_format)
 
 	this->name = ReadString(reader);
 
-	if (!new_format && this->GetName().compare("Corrupt sound") == 0) {
+	bool is_raw = !this->ReadSample(reader);
+	if (is_raw) {
 		/* In the old format there was one sample that was raw PCM. */
 		this->sample_data.resize(this->size);
 		reader.ReadRaw(this->sample_data.data(), this->sample_data.size());
 
 		this->size += RIFF_HEADER_SIZE;
-	} else {
-		this->ReadSample(reader);
 	}
 
 	if (!new_format) {
@@ -166,10 +171,16 @@ void Sample::ReadCatEntry(FileReader &reader, bool new_format)
 		this->bits_per_sample = 8;
 	}
 
-	/* Some kind of data byte, unused */
-	reader.ReadByte();
+	/* If name is 1 character then we're probably reading the DOS sample.cat, which does not contain filenames. */
+	if (!new_format && this->name.length() == 1) {
+		/* Construct a filename. */
+		this->filename = "wave" + std::to_string(index) + ".wav";
+	} else {
+		/* Some kind of data byte, unused */
+		reader.ReadByte();
 
-	this->filename = ReadString(reader);
+		this->filename = ReadString(reader);
+	}
 }
 
 void Sample::WriteSample(FileWriter &writer) const

--- a/src/sample.hpp
+++ b/src/sample.hpp
@@ -65,16 +65,18 @@ public:
 	 * This function has some very strict tests on validity of the input file.
 	 * @param reader     place to read the sample from
 	 * @param check_size whether to check that our size makes sense with the size from the sample
+	 * @return true if the sample was read.
 	 */
-	void ReadSample(FileReader &reader, bool check_size = true);
+	bool ReadSample(FileReader &reader, bool check_size = true);
 
 	/**
 	 * Reads a cat entry from a reader.
 	 * This function has some very strict tests on validity of the input file.
-	 * @param reader     place to read the cat entry from
+	 * @param reader place to read the cat entry from
 	 * @param new_format whether this is the old or new format; there are different strictness tests for both cases
+	 * @param index index of sample in cat header
 	 */
-	void ReadCatEntry(FileReader &reader, bool new_format);
+	void ReadCatEntry(FileReader &reader, bool new_format, uint32_t index);
 
 	/**
 	 * Write a sample to a writer. If only a sample is written to the


### PR DESCRIPTION
sample.cat from the DOS version of Transport Tycoon Deluxe uses a slightly different internal format than  the Windows version -- the extra filename information is not included.

Additionally all names are 1 character long, instead of being descriptions. 

There is nothing in the file spec that differentiates between the two formats, but we can misuse this knowledge of 1 character names to treat the DOS version differently.

This allows both the DOS and Windows sample.cats to be decoded.

It is however not possible to reencode and end up with the exact same file. When encoding catcodec will always include the filename, and it will always encode using the "new format" instead.