### PR TITLE
Codechange: Use ubuntu-latest in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
   source:
     name: Source
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout


### PR DESCRIPTION
`ubuntu-20.04` image doesn't exist any more, so use `ubuntu-latest` which should always exist.